### PR TITLE
Fix CoroutineScope in MainViewModel fetchUser()

### DIFF
--- a/app/src/main/java/com/mindorks/framework/mvi/ui/main/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/mindorks/framework/mvi/ui/main/viewmodel/MainViewModel.kt
@@ -37,14 +37,12 @@ class MainViewModel(
         }
     }
 
-    private fun fetchUser() {
-        viewModelScope.launch {
-            _state.value = MainState.Loading
-            _state.value = try {
-                MainState.Users(repository.getUsers())
-            } catch (e: Exception) {
-                MainState.Error(e.localizedMessage)
-            }
+    private suspend fun fetchUser() {
+        _state.value = MainState.Loading
+        _state.value = try {
+            MainState.Users(repository.getUsers())
+        } catch (e: Exception) {
+            MainState.Error(e.localizedMessage)
         }
     }
 }


### PR DESCRIPTION
I was going through this blog article https://blog.mindorks.com/mvi-architecture-android-tutorial-for-beginners-step-by-step-guide and downloaded this repo to learn more about MVI.

Anyways, I found this error (sort of) in the MainViewModel fetchUser(). The problem here is fetchUser() is already called from a different CoroutineScope. So instead of launching a new viewModelScope, we can reuse the previous one. So the PR request I raised removes the viewModelScope.launch {} and instead makes the fetchUser() suspend.